### PR TITLE
Support for owner/group/mode of the login.defs file

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) Jiri Tyr 2016
+Copyright (c) Jiri Tyr 2016-2020
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of
 this software and associated documentation files (the "Software"), to deal in

--- a/README.md
+++ b/README.md
@@ -58,6 +58,10 @@ List of variables used by the role:
 ```
 # Location of the login.defs file
 login_defs_file: /etc/login.defs
+# Owner/group/mode of the login.defs file
+login_defs_owner: root
+login_defs_group: root
+login_defs_mode: 0644
 
 # Default values of the default configuration
 login_defs_config_mail_dir: /var/spool/mail

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Please report any issues or send PR.
 Examples
 --------
 
-```
+```yaml
 ---
 
 # Example of how to use it without any changes
@@ -55,10 +55,11 @@ Role variables
 
 List of variables used by the role:
 
-```
+```yaml
 # Location of the login.defs file
 login_defs_file: /etc/login.defs
-# Owner/group/mode of the login.defs file
+
+# Permissions of the login.defs file
 login_defs_owner: root
 login_defs_group: root
 login_defs_mode: 0644
@@ -101,10 +102,8 @@ login_defs_config__custom: {}
 
 # Final cofiguration
 login_defs_config: "{{
-    login_defs_config__default.update(login_defs_config__custom)
-  }}{{
-    login_defs_config__default
-  }}"
+    login_defs_config__default | combine(
+    login_defs_config__custom) }}"
 ```
 
 

--- a/defaults/main.yaml
+++ b/defaults/main.yaml
@@ -2,6 +2,10 @@
 
 # Location of the login.defs file
 login_defs_file: /etc/login.defs
+# Owner/group/mode of the login.defs file
+login_defs_owner: root
+login_defs_group: root
+login_defs_mode: 0644
 
 # Default values of the default configuration
 login_defs_config_mail_dir: /var/spool/mail

--- a/defaults/main.yaml
+++ b/defaults/main.yaml
@@ -2,7 +2,8 @@
 
 # Location of the login.defs file
 login_defs_file: /etc/login.defs
-# Owner/group/mode of the login.defs file
+
+# Permissions of the login.defs file
 login_defs_owner: root
 login_defs_group: root
 login_defs_mode: 0644
@@ -45,7 +46,5 @@ login_defs_config__custom: {}
 
 # Final cofiguration
 login_defs_config: "{{
-    login_defs_config__default.update(login_defs_config__custom)
-  }}{{
-    login_defs_config__default
-  }}"
+    login_defs_config__default | combine(
+    login_defs_config__custom) }}"

--- a/meta/main.yaml
+++ b/meta/main.yaml
@@ -4,7 +4,7 @@ galaxy_info:
   author: Jiri Tyr
   description: Role which helps to manage the /etc/login.defs file.
   license: MIT
-  min_ansible_version: 2.0
+  min_ansible_version: 2.9
   platforms:
     - name: EL
       versions:
@@ -12,7 +12,7 @@ galaxy_info:
     - name: Debian
       versions:
         - all
-  categories:
+  galaxy_tags:
     - system
 dependencies:
   - config_encoder_filters

--- a/tasks/main.yaml
+++ b/tasks/main.yaml
@@ -4,5 +4,8 @@
   template:
     src: login.defs.j2
     dest: "{{ login_defs_file }}"
+    owner: "{{ login_defs_owner }}"
+    group: "{{ login_defs_group }}"
+    mode: "{{ login_defs_mode }}"
   tags:
     - login_defs_config


### PR DESCRIPTION
Hello Jiri!
I would like to add custom mode for login.defs because linux-baseline inspec profile require different permission to be set - https://github.com/dev-sec/linux-baseline/blob/master/controls/os_spec.rb#L145
Please review, thank you!